### PR TITLE
Save tasks as Markdown note

### DIFF
--- a/app/src/main/java/org/qosp/notes/data/sync/nextcloud/NextcloudManager.kt
+++ b/app/src/main/java/org/qosp/notes/data/sync/nextcloud/NextcloudManager.kt
@@ -245,6 +245,7 @@ class NextcloudManager(
 
     private suspend fun NextcloudNote.asUpdatedLocalNote(note: Note) = note.copy(
         title = title,
+        taskList = if (note.isList) note.mdToTaskList(content) else listOf(),
         content = content,
         isPinned = favorite,
         modifiedDate = modified,

--- a/app/src/main/java/org/qosp/notes/data/sync/nextcloud/model/NextcloudConverters.kt
+++ b/app/src/main/java/org/qosp/notes/data/sync/nextcloud/model/NextcloudConverters.kt
@@ -5,7 +5,7 @@ import org.qosp.notes.data.model.Note
 fun Note.asNextcloudNote(id: Long, category: String): NextcloudNote = NextcloudNote(
     id = id,
     title = title,
-    content = if (isList) taskListToString() else content,
+    content = if (isList) taskListToMd() else content,
     category = category,
     favorite = isPinned,
     modified = modifiedDate


### PR DESCRIPTION
This saves the tasks created in the app as :
```
- [ ] item 1
- [x] item 2
```
This is further editable in the nextcloud notes web app which will be reflected on the Quillnote tasks

Fixes #146